### PR TITLE
feat: add squads as available access filter option

### DIFF
--- a/src/Http/Controllers/AccessController.php
+++ b/src/Http/Controllers/AccessController.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Corporation\CorporationInfo;
 use Seat\Eveapi\Models\Corporation\CorporationTitle;
 use Seat\Web\Http\Controllers\Controller;
 use Seat\Web\Models\Acl\Role;
+use Seat\Web\Models\Squads\Squad;
 use Seat\Web\Models\User;
 use Warlof\Seat\Connector\Http\DataTables\AccessDataTable;
 use Warlof\Seat\Connector\Http\DataTables\Scopes\AccessDataTableScope;
@@ -73,6 +74,9 @@ class AccessController extends Controller
                 break;
             case 'alliances':
                 $filter_type = Alliance::class;
+                break;
+            case 'squads':
+                $filter_type = Squad::class;
                 break;
         }
 
@@ -178,6 +182,8 @@ class AccessController extends Controller
                 return 'titles';
             case Alliance::class:
                 return 'alliances';
+            case Squad::class:
+                return 'squads';
             default:
                 return $class_name;
         }

--- a/src/Http/Controllers/LookupController.php
+++ b/src/Http/Controllers/LookupController.php
@@ -25,6 +25,7 @@ use Illuminate\Http\Request;
 use Seat\Eveapi\Models\Corporation\CorporationTitle;
 use Seat\Web\Http\Controllers\Controller;
 use Seat\Web\Models\Acl\Role;
+use Seat\Web\Models\Squads\Squad;
 use Warlof\Seat\Connector\Models\Set;
 
 /**
@@ -72,6 +73,26 @@ class LookupController extends Controller
 
         return response()->json([
             'results' => $roles,
+        ]);
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getSquads(Request $request)
+    {
+        $squads = Squad::where('name', 'like', '%' . $request->query('q', '') . '%')
+                    ->get()
+                    ->map(function ($squad, $key) {
+                        return [
+                            'id'   => $squad->id,
+                            'text' => $squad->name,
+                        ];
+                    });
+
+        return response()->json([
+            'results' => $squads,
         ]);
     }
 

--- a/src/Http/Validations/AccessRuleValidation.php
+++ b/src/Http/Validations/AccessRuleValidation.php
@@ -26,6 +26,7 @@ use Seat\Eveapi\Models\Alliances\Alliance;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 use Seat\Eveapi\Models\Corporation\CorporationTitle;
 use Seat\Web\Models\Acl\Role;
+use Seat\Web\Models\Squads\Squad;
 use Seat\Web\Models\User;
 
 /**
@@ -60,6 +61,8 @@ class AccessRuleValidation extends FormRequest
             Alliance::class,
             'titles',
             CorporationTitle::class,
+            'squads',
+            Squad::class,
         ];
 
         return [

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -86,6 +86,10 @@ Route::group([
                     ->name('seat-connector.api.titles')
                     ->uses('LookupController@getTitles');
 
+                Route::get('/squads')
+                    ->name('seat-connector.api.squads')
+                    ->uses('LookupController@getSquads');
+
                 Route::get('/sets')
                     ->name('seat-connector.api.sets')
                     ->uses('LookupController@getSets');

--- a/src/Models/Set.php
+++ b/src/Models/Set.php
@@ -26,6 +26,7 @@ use Seat\Eveapi\Models\Alliances\Alliance;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
 use Seat\Eveapi\Models\Corporation\CorporationTitle;
 use Seat\Web\Models\Acl\Role;
+use Seat\Web\Models\Squads\Squad;
 use Seat\Web\Models\User;
 
 /**
@@ -100,6 +101,14 @@ class Set extends Model
     }
 
     /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
+     */
+    public function squads()
+    {
+        return $this->morphedByMany(Squad::class, 'entity', 'seat_connector_set_entity');
+    }
+
+    /**
      * @param array $options
      * @return bool
      */
@@ -115,6 +124,7 @@ class Set extends Model
             $this->alliances()->sync([]);
             $this->roles()->sync([]);
             $this->titles()->sync([]);
+            $this->squads()->sync([]);
         }
 
         return true;

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -106,6 +106,7 @@ class User extends Model
             ->union($this->getTitleSets())
             ->union($this->getAllianceSets())
             ->union($this->getPublicSets())
+            ->union($this->getSquadSets())
             ->get();
 
         $this->allowed_sets = $rows->unique('connector_id')->pluck('connector_id')->toArray();
@@ -185,6 +186,20 @@ class User extends Model
                 $alliances = $this->user->characters->pluck('affiliation.alliance_id');
 
                 $query->whereIn('entity_id', $alliances);
+            })
+            ->select('connector_id');
+
+        return $rows;
+    }
+
+    /**
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function getSquadSets()
+    {
+        $rows = Set::where('connector_type', $this->connector_type)
+            ->whereHas('squads', function ($query) {
+                $query->whereIn('entity_id', $this->user->squads->pluck('id'));
             })
             ->select('connector_id');
 

--- a/src/Observers/SquadMemberObserver.php
+++ b/src/Observers/SquadMemberObserver.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of seat-connector and provides user synchronization between both SeAT and third party platform
+ *
+ * Copyright (C) 2020  Loïc Leuilliot <loic.leuilliot@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Warlof\Seat\Connector\Observers;
+
+use Seat\Web\Models\Squads\SquadMember;
+use Seat\Web\Models\User as SeatUser;
+use Warlof\Seat\Connector\Jobs\NotifyDriver;
+
+/**
+ * Class SquadMemberObserver.
+ *
+ * @package Warlof\Seat\Connector\Observers
+ */
+class SquadMemberObserver
+{
+
+    /**
+     * @param \Seat\Web\Models\Squads\SquadMember $member
+     */
+    public function created(SquadMember $member)
+    {
+        $this->handle($member);
+    }
+
+    /**
+     * @param \Seat\Web\Models\Squads\SquadMember $member
+     */
+    public function updated(SquadMember $member)
+    {
+        $this->handle($member);
+    }
+
+    /**
+     * @param \Seat\Web\Models\Squads\SquadMember $member
+     */
+    public function deleted(SquadMember $member)
+    {
+        $this->handle($member);
+    }
+
+    /**
+     * @param \Seat\Web\Models\Squads\SquadMember $member
+     */
+    private function handle(SquadMember $member)
+    {
+        // attempt to retrieve attached user
+        $user = SeatUser::standard()
+            ->where('id', $member->user_id)
+            ->first();
+
+        if (! $user)
+            return;
+
+        dispatch(new NotifyDriver($user));
+    }
+}

--- a/src/SeatConnectorServiceProvider.php
+++ b/src/SeatConnectorServiceProvider.php
@@ -27,6 +27,7 @@ use Seat\Eveapi\Models\Character\CharacterAffiliation;
 use Seat\Services\AbstractSeatPlugin;
 use Seat\Web\Events\UserRoleAdded;
 use Seat\Web\Events\UserRoleRemoved;
+use Seat\Web\Models\Squads\SquadMember;
 use Warlof\Seat\Connector\Commands\DriverApplyPolicies;
 use Warlof\Seat\Connector\Commands\DriverUpdateSets;
 use Warlof\Seat\Connector\Events\EventLogger;
@@ -34,6 +35,7 @@ use Warlof\Seat\Connector\Listeners\LoggerListener;
 use Warlof\Seat\Connector\Listeners\UserRoleAddedListener;
 use Warlof\Seat\Connector\Listeners\UserRoleRemovedListener;
 use Warlof\Seat\Connector\Observers\CharacterAffiliationObserver;
+use Warlof\Seat\Connector\Observers\SquadMemberObserver;
 
 /**
  * Class SeatConnectorProvider.
@@ -196,7 +198,8 @@ class SeatConnectorServiceProvider extends AbstractSeatPlugin
         Event::listen(UserRoleAdded::class, UserRoleAddedListener::class);
         Event::listen(UserRoleRemoved::class, UserRoleRemovedListener::class);
 
-        // detect corporation and alliance affiliation updates
+        // detect corporation and alliance affiliation updates and squad membership updates
         CharacterAffiliation::observe(CharacterAffiliationObserver::class);
+        SquadMember::observe(SquadMemberObserver::class);
     }
 }

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -35,6 +35,7 @@ return [
     'corporation_filter' => 'Corporation Filters',
     'title_filter'       => 'Title Filters',
     'alliance_filter'    => 'Alliance Filters',
+    'squad_filter'       => 'Squad Filters',
 
     'driver'             => 'Driver',
     'sets'               => 'Set|Sets',

--- a/src/resources/views/access/includes/navigation.blade.php
+++ b/src/resources/views/access/includes/navigation.blade.php
@@ -34,4 +34,9 @@
       {{ trans('seat-connector::seat.alliance_filter') }}
     </a>
   </li>
+  <li class="nav-item">
+    <a href="#" class="nav-link" role="tab" data-toggle="pill" aria-expanded="true" data-filter="squads">
+      {{ trans('seat-connector::seat.squad_filter') }}
+    </a>
+  </li>
 </ul>

--- a/src/resources/views/access/includes/sidebar.blade.php
+++ b/src/resources/views/access/includes/sidebar.blade.php
@@ -26,6 +26,7 @@
             <option value="corporations">{{ trans('seat-connector::seat.corporation_filter') }}</option>
             <option value="titles">{{ trans('seat-connector::seat.title_filter') }}</option>
             <option value="alliances">{{ trans('seat-connector::seat.alliance_filter') }}</option>
+            <option value="squads">{{ trans('seat-connector::seat.squad_filter') }}</option>
           </select>
         </div>
 
@@ -52,6 +53,11 @@
         <div class="form-group">
           <label for="connector-filter-alliances">{{ trans('web::seat.alliance') }}</label>
           <select name="entity_id" id="connector-filter-alliances" class="form-control" disabled></select>
+        </div>
+
+        <div class="form-group">
+          <label for="connector-filter-alliances">{{ trans_choice('web::squads.squad', 1) }}</label>
+          <select name="entity_id" id="connector-filter-squads" class="form-control" disabled></select>
         </div>
 
         <div class="form-group">

--- a/src/resources/views/access/list.blade.php
+++ b/src/resources/views/access/list.blade.php
@@ -94,7 +94,7 @@
               dataType: 'json',
               cache: true
           },
-          minimumInputLength: 3
+          minimumInputLength: 1
       });
 
       $('#connector-driver')

--- a/src/resources/views/access/list.blade.php
+++ b/src/resources/views/access/list.blade.php
@@ -25,7 +25,7 @@
       $('#connector-filter-type').change(function() {
           var filter_type = $('#connector-filter-type').val();
 
-          $.each(['connector-filter-users', 'connector-filter-roles', 'connector-filter-corporations', 'connector-filter-titles', 'connector-filter-alliances'], function (key, value) {
+          $.each(['connector-filter-users', 'connector-filter-roles', 'connector-filter-corporations', 'connector-filter-titles', 'connector-filter-alliances', 'connector-filter-squads'], function (key, value) {
               if (value === ('connector-filter-' + filter_type)) {
                   $(('#' + value)).prop('disabled', false);
               } else {
@@ -82,6 +82,15 @@
       $('#connector-filter-alliances').select2({
           ajax: {
               url: '{{ route('fastlookup.alliances') }}',
+              dataType: 'json',
+              cache: true
+          },
+          minimumInputLength: 3
+      });
+
+      $('#connector-filter-squads').select2({
+          ajax: {
+              url: '{{ route('seat-connector.api.squads') }}',
               dataType: 'json',
               cache: true
           },


### PR DESCRIPTION
This allows squads to be used as a filter on the SeAT Connector drivers.

Closes warlof/seat-connector#49.