### PR TITLE
Fix to areAllTokensValid

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -69,7 +69,7 @@ class User extends Model
      */
     public function areAllTokensValid(): bool
     {
-        return $this->user->refresh_tokens->count() == $this->user->all_characters->count();
+        return $this->user->refresh_tokens->count() == $this->user->all_characters()->count();
     }
 
     /**


### PR DESCRIPTION
My Previous fix was incorrect, thinking all_characters was a relationship.

[User Model - Seat](https://github.com/eveseat/web/blob/225a3691e5d04293b516d961de17cc35af4a2bc8/src/Models/User.php#L173)
This function actually returns a collection, not a relationship.