### PR TITLE
Preparations for v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
   },
   "require": {
     "ext-json": "*",
-    "eveseat/services": "^4.1.1",
-    "eveseat/eveapi": "^4.0.0",
-    "eveseat/web": "^4.0.0",
-    "eveseat/api": "^4.0.0"
+    "eveseat/services": "^5.0",
+    "eveseat/eveapi": "^5.0",
+    "eveseat/web": "^5.0",
+    "eveseat/api": "^5.0"
   },
   "extra": {
     "laravel": {

--- a/src/Http/DataTables/AccessDataTable.php
+++ b/src/Http/DataTables/AccessDataTable.php
@@ -30,6 +30,7 @@ use Seat\Web\Models\Squads\Squad;
 use Seat\Web\Models\User;
 use Warlof\Seat\Connector\Models\Set;
 use Yajra\DataTables\Services\DataTable;
+use Illuminate\Http\JsonResponse;
 
 /**
  * Class AccessDataTable.
@@ -41,7 +42,7 @@ class AccessDataTable extends DataTable
      *
      * @throws \Exception
      */
-    public function ajax()
+    public function ajax(): JsonResponse
     {
         return datatables()
             ->query($this->applyScopes($this->query()))
@@ -115,8 +116,7 @@ class AccessDataTable extends DataTable
      */
     private function getCorporationQuery()
     {
-        $query = Set::
-            join('seat_connector_set_entity', 'set_id', 'id')
+        $query = Set::join('seat_connector_set_entity', 'set_id', 'id')
             ->join((new CorporationInfo())->getTable(), function ($join) {
                 $join->on('entity_id', 'corporation_id');
                 $join->where('entity_type', CorporationInfo::class);
@@ -128,7 +128,8 @@ class AccessDataTable extends DataTable
                 'seat_connector_sets.name',
                 'seat_connector_set_entity.entity_type',
                 'seat_connector_set_entity.entity_id',
-                (new CorporationInfo())->getTable() . '.name as entity_name');
+                (new CorporationInfo())->getTable() . '.name as entity_name'
+            );
 
         return $query;
     }
@@ -138,8 +139,7 @@ class AccessDataTable extends DataTable
      */
     private function getTitleQuery()
     {
-        $query = Set::
-            join('seat_connector_set_entity', 'set_id', 'seat_connector_sets.id')
+        $query = Set::join('seat_connector_set_entity', 'set_id', 'seat_connector_sets.id')
             ->join((new CorporationTitle())->getTable(), function ($join) {
                 $join->on('entity_id', (new CorporationTitle())->getTable() . '.id')
                     ->where('entity_type', CorporationTitle::class);
@@ -151,7 +151,8 @@ class AccessDataTable extends DataTable
                 'seat_connector_sets.name',
                 'seat_connector_set_entity.entity_type',
                 'seat_connector_set_entity.entity_id',
-                (new CorporationTitle())->getTable() . '.name as entity_name');
+                (new CorporationTitle())->getTable() . '.name as entity_name'
+            );
 
         return $query;
     }
@@ -161,8 +162,7 @@ class AccessDataTable extends DataTable
      */
     private function getAllianceQuery()
     {
-        $query = Set::
-            join('seat_connector_set_entity', 'set_id', 'id')
+        $query = Set::join('seat_connector_set_entity', 'set_id', 'id')
             ->join((new Alliance())->getTable(), function ($join) {
                 $join->on('entity_id', 'alliance_id');
                 $join->where('entity_type', Alliance::class);
@@ -174,7 +174,8 @@ class AccessDataTable extends DataTable
                 'seat_connector_sets.name',
                 'seat_connector_set_entity.entity_type',
                 'seat_connector_set_entity.entity_id',
-                (new Alliance())->getTable() . '.name as entity_name');
+                (new Alliance())->getTable() . '.name as entity_name'
+            );
 
         return $query;
     }
@@ -184,8 +185,7 @@ class AccessDataTable extends DataTable
      */
     private function getRoleQuery()
     {
-        $query = Set::
-            join('seat_connector_set_entity', 'set_id', 'id')
+        $query = Set::join('seat_connector_set_entity', 'set_id', 'id')
             ->join((new Role())->getTable(), function ($join) {
                 $join->on('entity_id', (new Role())->getTable() . '.id');
                 $join->where('entity_type', Role::class);
@@ -197,7 +197,8 @@ class AccessDataTable extends DataTable
                 'seat_connector_sets.name',
                 'seat_connector_set_entity.entity_type',
                 'seat_connector_set_entity.entity_id',
-                (new Role())->getTable() . '.title as entity_name');
+                (new Role())->getTable() . '.title as entity_name'
+            );
 
         return $query;
     }
@@ -207,8 +208,7 @@ class AccessDataTable extends DataTable
      */
     private function getUserQuery()
     {
-        $query = Set::
-            join('seat_connector_set_entity', 'set_id', 'id')
+        $query = Set::join('seat_connector_set_entity', 'set_id', 'id')
             ->join((new User())->getTable(), function ($join) {
                 $join->on('entity_id', (new User())->getTable() . '.id');
                 $join->where('entity_type', User::class);
@@ -220,7 +220,8 @@ class AccessDataTable extends DataTable
                 'seat_connector_sets.name',
                 'seat_connector_set_entity.entity_type',
                 'seat_connector_set_entity.entity_id',
-                (new User())->getTable() . '.name as entity_name');
+                (new User())->getTable() . '.name as entity_name'
+            );
 
         return $query;
     }
@@ -247,8 +248,7 @@ class AccessDataTable extends DataTable
      */
     private function getSquadQuery()
     {
-        $query = Set::
-            join('seat_connector_set_entity', 'set_id', 'id')
+        $query = Set::join('seat_connector_set_entity', 'set_id', 'id')
             ->join((new Squad())->getTable(), function ($join) {
                 $join->on('entity_id', (new Squad())->getTable() . '.id');
                 $join->where('entity_type', Squad::class);
@@ -260,7 +260,8 @@ class AccessDataTable extends DataTable
                 'seat_connector_sets.name',
                 'seat_connector_set_entity.entity_type',
                 'seat_connector_set_entity.entity_id',
-                (new Squad())->getTable() . '.name as entity_name');
+                (new Squad())->getTable() . '.name as entity_name'
+            );
 
         return $query;
     }

--- a/src/Http/DataTables/AccessDataTable.php
+++ b/src/Http/DataTables/AccessDataTable.php
@@ -21,6 +21,7 @@
 
 namespace Warlof\Seat\Connector\Http\DataTables;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Seat\Eveapi\Models\Alliances\Alliance;
 use Seat\Eveapi\Models\Corporation\CorporationInfo;
@@ -30,7 +31,6 @@ use Seat\Web\Models\Squads\Squad;
 use Seat\Web\Models\User;
 use Warlof\Seat\Connector\Models\Set;
 use Yajra\DataTables\Services\DataTable;
-use Illuminate\Http\JsonResponse;
 
 /**
  * Class AccessDataTable.

--- a/src/Http/DataTables/LogsDataTable.php
+++ b/src/Http/DataTables/LogsDataTable.php
@@ -23,6 +23,7 @@ namespace Warlof\Seat\Connector\Http\DataTables;
 
 use Warlof\Seat\Connector\Models\Log;
 use Yajra\DataTables\Services\DataTable;
+use Illuminate\Http\JsonResponse;
 
 /**
  * Class LogsDataTable.
@@ -34,7 +35,7 @@ class LogsDataTable extends DataTable
      *
      * @throws \Exception
      */
-    public function ajax()
+    public function ajax(): JsonResponse
     {
         return datatables()
             ->eloquent($this->applyScopes($this->query()))

--- a/src/Http/DataTables/LogsDataTable.php
+++ b/src/Http/DataTables/LogsDataTable.php
@@ -21,9 +21,9 @@
 
 namespace Warlof\Seat\Connector\Http\DataTables;
 
+use Illuminate\Http\JsonResponse;
 use Warlof\Seat\Connector\Models\Log;
 use Yajra\DataTables\Services\DataTable;
-use Illuminate\Http\JsonResponse;
 
 /**
  * Class LogsDataTable.

--- a/src/Http/DataTables/UserMappingDataTable.php
+++ b/src/Http/DataTables/UserMappingDataTable.php
@@ -21,9 +21,9 @@
 
 namespace Warlof\Seat\Connector\Http\DataTables;
 
+use Illuminate\Http\JsonResponse;
 use Warlof\Seat\Connector\Models\User;
 use Yajra\DataTables\Services\DataTable;
-use Illuminate\Http\JsonResponse;
 
 /**
  * Class UserMappingDataTable.

--- a/src/Http/DataTables/UserMappingDataTable.php
+++ b/src/Http/DataTables/UserMappingDataTable.php
@@ -23,6 +23,7 @@ namespace Warlof\Seat\Connector\Http\DataTables;
 
 use Warlof\Seat\Connector\Models\User;
 use Yajra\DataTables\Services\DataTable;
+use Illuminate\Http\JsonResponse;
 
 /**
  * Class UserMappingDataTable.
@@ -34,7 +35,7 @@ class UserMappingDataTable extends DataTable
      *
      * @throws \Exception
      */
-    public function ajax()
+    public function ajax(): JsonResponse
     {
         return datatables()
             ->eloquent($this->applyScopes($this->query()))

--- a/src/resources/views/access/list.blade.php
+++ b/src/resources/views/access/list.blade.php
@@ -5,12 +5,12 @@
 
 @section('left')
 
-  @include('seat-connector::access.includes.sidebar')
+    @include('seat-connector::access.includes.sidebar')
 
 @stop
 
 @section('right')
-    @if(empty(config('seat-connector.drivers', [])))
+    @if (empty(config('seat-connector.drivers', [])))
         <div class="callout callout-warning">
             <h4>No driver available!</h4>
             <p>In order to use this page, you need to install a seat-connector driver.</p>
@@ -21,109 +21,111 @@
 @stop
 
 @push('javascript')
-  <script>
-      $('#connector-filter-type').change(function() {
-          var filter_type = $('#connector-filter-type').val();
+    <script>
+        $('#connector-filter-type').change(function() {
+            var filter_type = $('#connector-filter-type').val();
 
-          $.each(['connector-filter-users', 'connector-filter-roles', 'connector-filter-corporations', 'connector-filter-titles', 'connector-filter-alliances', 'connector-filter-squads'], function (key, value) {
-              if (value === ('connector-filter-' + filter_type)) {
-                  $(('#' + value)).prop('disabled', false);
-              } else {
-                  $(('#' + value)).prop('disabled', true);
-              }
-          });
+            $.each(['connector-filter-users', 'connector-filter-roles', 'connector-filter-corporations',
+                'connector-filter-titles', 'connector-filter-alliances', 'connector-filter-squads'
+            ], function(key, value) {
+                if (value === ('connector-filter-' + filter_type)) {
+                    $(('#' + value)).prop('disabled', false);
+                } else {
+                    $(('#' + value)).prop('disabled', true);
+                }
+            });
 
-          if (filter_type === 'titles')
-              $('#connector-filter-corporations, #connector-filter-titles').prop('disabled', false);
-      }).select2();
+            if (filter_type === 'titles')
+                $('#connector-filter-corporations, #connector-filter-titles').prop('disabled', false);
+        }).select2();
 
-      $('#connector-filter-users').select2({
-          ajax: {
-              url: '{{ route('fastlookup.users') }}',
-              dataType: 'json',
-              cache: true
-          },
-          minimumInputLength: 3
-      });
+        $('#connector-filter-users').select2({
+            ajax: {
+                url: '{{ route('seatcore::fastlookup.users') }}',
+                dataType: 'json',
+                cache: true
+            },
+            minimumInputLength: 3
+        });
 
-      $('#connector-filter-roles').select2({
-          ajax: {
-              url: '{{ route('seat-connector.api.roles') }}',
-              dataType: 'json',
-              cache: true
-          },
-          minimumInputLength: 1
-      });
+        $('#connector-filter-roles').select2({
+            ajax: {
+                url: '{{ route('seat-connector.api.roles') }}',
+                dataType: 'json',
+                cache: true
+            },
+            minimumInputLength: 1
+        });
 
-      $('#connector-filter-corporations').select2({
-          ajax: {
-              url: '{{ route('fastlookup.corporations') }}',
-              dataType: 'json',
-              cache: true
-          },
-          minimumInputLength: 3
-      });
+        $('#connector-filter-corporations').select2({
+            ajax: {
+                url: '{{ route('seatcore::fastlookup.corporations') }}',
+                dataType: 'json',
+                cache: true
+            },
+            minimumInputLength: 3
+        });
 
-      $('#connector-filter-titles').select2({
-          ajax: {
-              url: '{{ route('seat-connector.api.titles') }}',
-              data: function (params) {
-                  return {
-                      q: params.term,
-                      corporation_id: $('#connector-filter-corporations').val()
-                  };
-              },
-              dataType: 'json',
-              cache: true
-          },
-          minimumInputLength: 1
-      });
+        $('#connector-filter-titles').select2({
+            ajax: {
+                url: '{{ route('seat-connector.api.titles') }}',
+                data: function(params) {
+                    return {
+                        q: params.term,
+                        corporation_id: $('#connector-filter-corporations').val()
+                    };
+                },
+                dataType: 'json',
+                cache: true
+            },
+            minimumInputLength: 1
+        });
 
-      $('#connector-filter-alliances').select2({
-          ajax: {
-              url: '{{ route('fastlookup.alliances') }}',
-              dataType: 'json',
-              cache: true
-          },
-          minimumInputLength: 3
-      });
+        $('#connector-filter-alliances').select2({
+            ajax: {
+                url: '{{ route('seatcore::fastlookup.alliances') }}',
+                dataType: 'json',
+                cache: true
+            },
+            minimumInputLength: 3
+        });
 
-      $('#connector-filter-squads').select2({
-          ajax: {
-              url: '{{ route('seat-connector.api.squads') }}',
-              dataType: 'json',
-              cache: true
-          },
-          minimumInputLength: 1
-      });
+        $('#connector-filter-squads').select2({
+            ajax: {
+                url: '{{ route('seat-connector.api.squads') }}',
+                dataType: 'json',
+                cache: true
+            },
+            minimumInputLength: 1
+        });
 
-      $('#connector-driver')
-          .change(function () {
-              window.LaravelDataTables["dataTableBuilder"].ajax.reload();
-          })
-          .select2();
+        $('#connector-driver')
+            .change(function() {
+                window.LaravelDataTables["dataTableBuilder"].ajax.reload();
+            })
+            .select2();
 
-      $('#connector-set').select2({
-          ajax: {
-              url: '{{ route('seat-connector.api.sets') }}',
-              data: function (params) {
-                  return {
-                      q: params.term,
-                      driver: $('#connector-driver').val()
-                  };
-              },
-              dataType: 'json',
-              cache: true
-          },
-          minimumInputLength: 1
-      });
+        $('#connector-set').select2({
+            ajax: {
+                url: '{{ route('seat-connector.api.sets') }}',
+                data: function(params) {
+                    return {
+                        q: params.term,
+                        driver: $('#connector-driver').val()
+                    };
+                },
+                dataType: 'json',
+                cache: true
+            },
+            minimumInputLength: 1
+        });
 
-      $('#connector-table-filters li a').click(function() {
-          $('#connector-table-filters a.active').removeClass('active');
-          $(this).addClass('active');
+        $('#connector-table-filters li a').click(function() {
+            $('#connector-table-filters a.active').removeClass('active');
+            $(this).addClass('active');
 
-          window.LaravelDataTables["dataTableBuilder"].ajax.reload();
-      });
-  </script>
-  {!! $dataTable->scripts() !!}
+            window.LaravelDataTables["dataTableBuilder"].ajax.reload();
+        });
+    </script>
+    {!! $dataTable->scripts() !!}
 @endpush


### PR DESCRIPTION
- Bumped `eveseat/services`, `eveseat/eveapi`, `eveseat/web`, and `eveseat/api` to `^5.0` (previously between `^4.0` and `^4.1.1`)
- Added `JsonResponse` typing to `DataTables`
- Fixed `fastlookup` routes to use the new prefix of v5 `seat::fastlookup.x`